### PR TITLE
Add optional LLM entity extraction pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ This project provides a backend-focused toolkit for managing collaborative graph
 pip install -r requirements-dev.txt
 ```
 
+### Environment variables
+
+If you would like to augment entity extraction with a hosted large language model, provide the following environment variables before starting the API service:
+
+| Variable | Purpose |
+| --- | --- |
+| `DIAGRAM_LLM_API_KEY` | API key for the diagram extraction model (e.g. OpenAI). |
+| `DIAGRAM_LLM_BASE_URL` | Optional. Override the base URL for the LLM API (defaults to `https://api.openai.com/v1`). |
+| `DIAGRAM_LLM_MODEL` | Optional. Override the model name (defaults to `gpt-4o-mini`). |
+
+When these values are absent the service falls back to the built-in heuristic pipeline so tests and offline development continue to function.
+
 ## Running Tests
 
 ```bash

--- a/services/api/src/llm/entityExtractor.ts
+++ b/services/api/src/llm/entityExtractor.ts
@@ -1,0 +1,152 @@
+import { DiagramFormat, RolePreset } from '../types.js';
+
+export interface LLMEntityExtraction {
+  entities: string[];
+  diagramType?: DiagramFormat;
+}
+
+export interface LLMEntityExtractorOptions {
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+}
+
+type MessageHistory = Array<{ role: 'user' | 'assistant'; content: string }>;
+
+type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+  json(): Promise<unknown>;
+}>;
+
+interface OpenAIResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+  output_text?: string[];
+}
+
+export class LLMEntityExtractor {
+  private options: LLMEntityExtractorOptions;
+  private fetch: FetchLike | undefined;
+
+  constructor(options: LLMEntityExtractorOptions = {}) {
+    this.options = options;
+    this.fetch = typeof fetch === 'function' ? (fetch as FetchLike) : undefined;
+  }
+
+  isConfigured(): boolean {
+    return Boolean(this.getApiKey() && this.fetch);
+  }
+
+  async extract(history: MessageHistory, role: RolePreset): Promise<LLMEntityExtraction | null> {
+    if (!this.isConfigured()) {
+      return null;
+    }
+
+    const apiKey = this.getApiKey();
+    const baseUrl = this.options.baseUrl ?? process.env.DIAGRAM_LLM_BASE_URL ?? 'https://api.openai.com/v1';
+    const model = this.options.model ?? process.env.DIAGRAM_LLM_MODEL ?? 'gpt-4o-mini';
+    const url = `${baseUrl.replace(/\/$/, '')}/responses`;
+
+    const systemPrompt = [
+      'You translate chat history into diagram inputs.',
+      'Return strict JSON with fields: entities (array of concise node labels) and diagramType ("mermaid" or "mindmap").',
+      'Prefer mermaid for procedural or sequential flows and mindmap for brainstorming or hierarchies.',
+      'Never include any additional text.',
+    ].join(' ');
+
+    const transcript = history
+      .map((item) => `${item.role === 'assistant' ? 'Assistant' : 'User'}: ${item.content}`)
+      .join('\n');
+
+    try {
+      const response = await this.fetch!(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model,
+          input: [
+            { role: 'system', content: systemPrompt },
+            {
+              role: 'user',
+              content: [
+                `Session role: ${role}.`,
+                'Derive diagram inputs from the following transcript:',
+                transcript,
+              ].join('\n'),
+            },
+          ],
+          response_format: {
+            type: 'json_schema',
+            json_schema: {
+              name: 'diagram_entities',
+              schema: {
+                type: 'object',
+                required: ['entities'],
+                properties: {
+                  entities: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description: 'Ordered list of diagram node labels.',
+                  },
+                  diagramType: {
+                    type: 'string',
+                    enum: ['mermaid', 'mindmap'],
+                  },
+                },
+              },
+            },
+          },
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`LLM request failed with status ${response.status}`);
+      }
+
+      const payload = (await response.json()) as OpenAIResponse;
+      const text = this.extractText(payload);
+      if (!text) {
+        throw new Error('Missing response text from LLM');
+      }
+      const parsed = JSON.parse(text) as LLMEntityExtraction;
+      const entities = Array.isArray(parsed.entities) ? parsed.entities.filter((item) => typeof item === 'string') : [];
+      const diagramType = parsed.diagramType === 'mermaid' || parsed.diagramType === 'mindmap' ? parsed.diagramType : undefined;
+      if (entities.length === 0) {
+        return null;
+      }
+      return { entities, diagramType };
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'test') {
+        console.warn('LLM extraction failed:', error);
+      }
+      return null;
+    }
+  }
+
+  private extractText(response: OpenAIResponse): string | null {
+    const fromChoices = response.choices?.[0]?.message?.content;
+    if (fromChoices) {
+      return fromChoices;
+    }
+    const fromOutput = response.output_text?.[0];
+    if (fromOutput) {
+      return fromOutput;
+    }
+    return null;
+  }
+
+  private getApiKey(): string | undefined {
+    return this.options.apiKey ?? process.env.DIAGRAM_LLM_API_KEY ?? process.env.OPENAI_API_KEY;
+  }
+}

--- a/services/api/test/service.test.ts
+++ b/services/api/test/service.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { DiagramService } from '../src/service.js';
 
 describe('DiagramService', () => {
-  it('creates session and generates mermaid DSL with guard rails', () => {
+  it('creates session and generates mermaid DSL with guard rails', async () => {
     const service = new DiagramService();
     const session = service.createSession('planner');
 
-    const result = service.processMessage({
+    const result = await service.processMessage({
       sessionId: session.id,
       content: 'Process order intake -> Validate payment -> Schedule delivery for client alice@example.com',
     });
@@ -19,11 +19,11 @@ describe('DiagramService', () => {
     expect(result.diff.addedNodes).toHaveLength(3);
   });
 
-  it('flags isolated nodes and masks PII', () => {
+  it('flags isolated nodes and masks PII', async () => {
     const service = new DiagramService();
     const session = service.createSession('analyst');
 
-    const result = service.processMessage({
+    const result = await service.processMessage({
       sessionId: session.id,
       content: 'Escalation contact 555-555-5555',
     });
@@ -33,11 +33,11 @@ describe('DiagramService', () => {
     expect(layoutLabels.join(' ')).not.toContain('555');
   });
 
-  it('generates mindmap DSL when brainstorming context is detected', () => {
+  it('generates mindmap DSL when brainstorming context is detected', async () => {
     const service = new DiagramService();
     const session = service.createSession('facilitator');
 
-    service.processMessage({
+    await service.processMessage({
       sessionId: session.id,
       content: 'Brainstorm ideas for launch including Marketing Plan, Engineering tasks, Customer Support readiness',
     });
@@ -47,11 +47,11 @@ describe('DiagramService', () => {
     expect(exportPayload.contract?.diagram.dsl).toMatchSnapshot('mindmap-dsl');
   });
 
-  it('allows reformatting a diagram into a different format', () => {
+  it('allows reformatting a diagram into a different format', async () => {
     const service = new DiagramService();
     const session = service.createSession('analyst');
 
-    service.processMessage({
+    await service.processMessage({
       sessionId: session.id,
       content: 'System components: API Gateway, Auth Service, Data Lake, BI Dashboard',
     });


### PR DESCRIPTION
## Summary
- add an optional LLM entity extractor that uses environment-configured credentials to analyse chat history
- update the diagram service and message routes to await LLM responses while falling back to heuristics
- document required environment variables and adjust tests for the async API

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e05b8140848321b569e83027ed0842