### PR TITLE
Add voice input support to chat panel

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -117,6 +117,14 @@
   gap: 1rem;
 }
 
+.chat-actions-buttons {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 .hint {
   color: #9ca3af;
   font-size: 0.8rem;

--- a/apps/web/src/hooks/useSpeechRecognition.ts
+++ b/apps/web/src/hooks/useSpeechRecognition.ts
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+type SpeechRecognitionCallback = (transcript: string) => void
+
+type RecognitionAlternative = {
+  transcript: string
+}
+
+type RecognitionResult = {
+  isFinal: boolean
+  length: number
+  [index: number]: RecognitionAlternative
+}
+
+type RecognitionEvent = Event & {
+  resultIndex: number
+  results: {
+    length: number
+    [index: number]: RecognitionResult
+  }
+}
+
+type RecognitionInstance = {
+  lang: string
+  continuous: boolean
+  interimResults: boolean
+  start: () => void
+  stop: () => void
+  addEventListener: (type: 'result' | 'end' | 'error', listener: (event: unknown) => void) => void
+  removeEventListener: (type: 'result' | 'end' | 'error', listener: (event: unknown) => void) => void
+}
+
+type RecognitionConstructor = new () => RecognitionInstance
+
+interface UseSpeechRecognitionOptions {
+  lang?: string
+  interimResults?: boolean
+  continuous?: boolean
+  onResult?: SpeechRecognitionCallback
+}
+
+export const useSpeechRecognition = ({
+  lang,
+  interimResults = false,
+  continuous = false,
+  onResult,
+}: UseSpeechRecognitionOptions = {}) => {
+  const [supported, setSupported] = useState(false)
+  const [listening, setListening] = useState(false)
+  const recognitionRef = useRef<RecognitionInstance | null>(null)
+  const onResultRef = useRef<SpeechRecognitionCallback | undefined>(onResult)
+
+  useEffect(() => {
+    onResultRef.current = onResult
+  }, [onResult])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const SpeechRecognitionCtor: RecognitionConstructor | undefined =
+      (window as typeof window & {
+        SpeechRecognition?: RecognitionConstructor
+        webkitSpeechRecognition?: RecognitionConstructor
+      }).SpeechRecognition ??
+      (window as typeof window & {
+        SpeechRecognition?: RecognitionConstructor
+        webkitSpeechRecognition?: RecognitionConstructor
+      }).webkitSpeechRecognition
+
+    if (!SpeechRecognitionCtor) {
+      setSupported(false)
+      return
+    }
+
+    const recognition = new SpeechRecognitionCtor()
+    recognition.lang = lang ?? (typeof navigator !== 'undefined' ? navigator.language : 'en-US')
+    recognition.interimResults = interimResults
+    recognition.continuous = continuous
+
+    const handleResult = (event: unknown) => {
+      const recognitionEvent = event as RecognitionEvent
+      const result = recognitionEvent.results[recognitionEvent.resultIndex]
+      if (!result || !result.isFinal) return
+
+      const transcript = Array.from({ length: result.length }, (_, index) => result[index]?.transcript.trim())
+        .filter(Boolean)
+        .join(' ')
+
+      if (transcript && onResultRef.current) {
+        onResultRef.current(transcript)
+      }
+    }
+
+    const handleEnd = () => {
+      setListening(false)
+    }
+
+    const handleError = () => {
+      setListening(false)
+    }
+
+    recognition.addEventListener('result', handleResult)
+    recognition.addEventListener('end', handleEnd)
+    recognition.addEventListener('error', handleError)
+
+    recognitionRef.current = recognition
+    setSupported(true)
+
+    return () => {
+      recognition.removeEventListener('result', handleResult)
+      recognition.removeEventListener('end', handleEnd)
+      recognition.removeEventListener('error', handleError)
+      recognition.stop()
+      recognitionRef.current = null
+    }
+  }, [continuous, interimResults, lang])
+
+  const start = useCallback(() => {
+    const recognition = recognitionRef.current
+    if (!recognition || listening) return
+
+    try {
+      recognition.start()
+      setListening(true)
+    } catch (error) {
+      const domError = error as DOMException
+      if (domError.name === 'InvalidStateError') {
+        recognition.stop()
+        recognition.start()
+        setListening(true)
+      }
+    }
+  }, [listening])
+
+  const stop = useCallback(() => {
+    const recognition = recognitionRef.current
+    if (!recognition) return
+
+    recognition.stop()
+    setListening(false)
+  }, [])
+
+  return {
+    supported,
+    listening,
+    start,
+    stop,
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable speech recognition hook for browser-based dictation
- integrate microphone controls and hints into the chat panel input area
- adjust chat action layout styles to accommodate the new voice button

## Testing
- npm --prefix apps/web run build

------
https://chatgpt.com/codex/tasks/task_e_68e05e1a46a48321b34e71ee1c2f7dbd