### PR TITLE
Populate chat input after speech dictation

### DIFF
--- a/apps/web/src/components/ChatPanel.tsx
+++ b/apps/web/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, KeyboardEvent, useMemo, useState } from 'react'
+import { FormEvent, KeyboardEvent, useEffect, useMemo, useState } from 'react'
 import { useAppStore } from '../state/store'
 import clsx from 'clsx'
 import { useSpeechRecognition } from '../hooks/useSpeechRecognition'
@@ -17,19 +17,26 @@ export const ChatPanel = () => {
   const appendHistory = useAppStore((state) => state.appendHistory)
   const toggleCommandPalette = useAppStore((state) => state.toggleCommandPalette)
   const activeRole = useAppStore((state) => state.activeRole)
-  const { supported: speechSupported, listening: isListening, start: startListening, stop: stopListening } =
-    useSpeechRecognition({
-      onResult: (transcript) => {
-        setInput((previous) => {
-          if (!previous) {
-            return transcript
-          }
+  const {
+    supported: speechSupported,
+    listening: isListening,
+    start: startListening,
+    stop: stopListening,
+    transcript,
+  } = useSpeechRecognition()
 
-          const needsSpace = !previous.endsWith(' ') && !previous.endsWith('\n')
-          return `${previous}${needsSpace ? ' ' : ''}${transcript}`
-        })
-      },
-    })
+  useEffect(() => {
+    if (!isListening && transcript) {
+      setInput((previous) => {
+        if (!previous) {
+          return transcript
+        }
+
+        const needsSpace = !previous.endsWith(' ') && !previous.endsWith('\n')
+        return `${previous}${needsSpace ? ' ' : ''}${transcript}`
+      })
+    }
+  }, [isListening, transcript])
 
   const sortedMessages = useMemo(() => chat.slice().sort((a, b) => a.createdAt.localeCompare(b.createdAt)), [chat])
 

--- a/apps/web/src/hooks/useSpeechRecognition.ts
+++ b/apps/web/src/hooks/useSpeechRecognition.ts
@@ -47,8 +47,10 @@ export const useSpeechRecognition = ({
 }: UseSpeechRecognitionOptions = {}) => {
   const [supported, setSupported] = useState(false)
   const [listening, setListening] = useState(false)
+  const [transcript, setTranscript] = useState('')
   const recognitionRef = useRef<RecognitionInstance | null>(null)
   const onResultRef = useRef<SpeechRecognitionCallback | undefined>(onResult)
+  const transcriptRef = useRef('')
 
   useEffect(() => {
     onResultRef.current = onResult
@@ -88,7 +90,15 @@ export const useSpeechRecognition = ({
         .filter(Boolean)
         .join(' ')
 
-      if (transcript && onResultRef.current) {
+      if (!transcript) return
+
+      transcriptRef.current = transcriptRef.current
+        ? `${transcriptRef.current} ${transcript}`.replace(/\s+/g, ' ').trim()
+        : transcript
+
+      setTranscript(transcriptRef.current)
+
+      if (onResultRef.current) {
         onResultRef.current(transcript)
       }
     }
@@ -122,12 +132,16 @@ export const useSpeechRecognition = ({
     if (!recognition || listening) return
 
     try {
+      transcriptRef.current = ''
+      setTranscript('')
       recognition.start()
       setListening(true)
     } catch (error) {
       const domError = error as DOMException
       if (domError.name === 'InvalidStateError') {
         recognition.stop()
+        transcriptRef.current = ''
+        setTranscript('')
         recognition.start()
         setListening(true)
       }
@@ -147,5 +161,6 @@ export const useSpeechRecognition = ({
     listening,
     start,
     stop,
+    transcript,
   }
 }


### PR DESCRIPTION
## Summary
- accumulate speech recognition transcripts and expose them after dictation stops
- populate the chat textarea with the completed transcript once listening ends

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e27f6217308321bd33ff198615d8d2