### PR TITLE
Improve voice dictation UX

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -110,6 +110,48 @@
   background: rgba(255, 255, 255, 0.7);
 }
 
+.chat-input textarea.voice-capturing {
+  border-color: rgba(37, 99, 235, 0.65);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.18);
+  background: rgba(37, 99, 235, 0.05);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.chat-input textarea.voice-capturing::placeholder {
+  color: rgba(37, 99, 235, 0.6);
+}
+
+.chat-actions .hint[data-voice-active='true'] {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.chat-actions .hint[data-voice-active='true']::before {
+  content: '';
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: rgba(37, 99, 235, 0.45);
+  animation: pulse 1.2s ease-in-out infinite;
+  display: inline-block;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(0.9);
+    opacity: 0.7;
+  }
+  50% {
+    transform: scale(1.2);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(0.9);
+    opacity: 0.7;
+  }
+}
+
 .chat-actions {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- enhance the chat panel voice dictation flow with automatic submission, clearer hints, and read-only handling while capturing speech
- surface interim speech recognition transcripts to the UI and style the textarea and status hint during voice capture
- extend the speech recognition hook to emit interim transcripts and reset state between sessions

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e2890c873c83218a110c5a5e47bf6f