### PR TITLE
feat: auto render diagrams after chat messages

### DIFF
--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -1,5 +1,116 @@
 import type { DiagramSnapshot } from '../state/store'
 
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:3333'
+
+const buildUrl = (path: string) => {
+  const normalizedBase = API_BASE_URL.replace(/\/$/, '')
+  return `${normalizedBase}${path}`
+}
+
+const parseResponse = async <T>(response: Response): Promise<T> => {
+  const text = await response.text()
+  if (!response.ok) {
+    const message = text || response.statusText || 'Request failed'
+    throw new Error(message)
+  }
+  try {
+    return text ? (JSON.parse(text) as T) : ({} as T)
+  } catch (error) {
+    throw new Error('Failed to parse server response')
+  }
+}
+
+export type ApiRolePreset = 'analyst' | 'facilitator' | 'planner'
+
+export interface SessionResponse {
+  id: string
+  role: ApiRolePreset
+  createdAt: string
+}
+
+export interface MindmapNodePayload {
+  id: string
+  label: string
+  level?: number
+}
+
+export interface MindmapEdgePayload {
+  source: string
+  target: string
+  label?: string | null
+}
+
+export interface MindmapDSL {
+  root: string
+  nodes: MindmapNodePayload[]
+  edges: MindmapEdgePayload[]
+}
+
+export interface DiagramNodePayload {
+  id: string
+  label: string
+  type?: string
+  level?: number
+}
+
+export interface DiagramEdgePayload {
+  id: string
+  source: string
+  target: string
+  label?: string
+}
+
+export interface DiagramPayloadResponse {
+  format: 'mermaid' | 'mindmap'
+  dsl: string | MindmapDSL
+  layout: {
+    nodes: Array<DiagramNodePayload & { x: number; y: number }>
+    edges: DiagramEdgePayload[]
+  }
+  confidence: number
+}
+
+export interface DiffPatchResponse {
+  addedNodes: DiagramNodePayload[]
+  removedNodes: DiagramNodePayload[]
+  addedEdges: DiagramEdgePayload[]
+  removedEdges: DiagramEdgePayload[]
+}
+
+export interface DiagramContractResponse {
+  diagram: DiagramPayloadResponse
+  conflicts: string[]
+}
+
+export interface ProcessMessageResponse {
+  diagram: DiagramPayloadResponse
+  conflicts: string[]
+  diff: DiffPatchResponse
+  systemPrompt: string
+}
+
+export const createSession = async (role: ApiRolePreset): Promise<SessionResponse> => {
+  const response = await fetch(buildUrl('/v1/sessions'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ role }),
+  })
+  return parseResponse<SessionResponse>(response)
+}
+
+export const processChatMessage = async (
+  sessionId: string,
+  content: string,
+  metadata?: Record<string, unknown>,
+): Promise<ProcessMessageResponse> => {
+  const response = await fetch(buildUrl('/v1/messages'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sessionId, content, metadata }),
+  })
+  return parseResponse<ProcessMessageResponse>(response)
+}
+
 export const requestCommandExecution = async (command: string, snapshot: DiagramSnapshot) => {
   console.info('[api] command dispatched (stub)', command, snapshot)
   await new Promise((resolve) => setTimeout(resolve, 150))

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -1,6 +1,7 @@
 import type { DiagramSnapshot } from '../state/store'
 
-const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? 'http://localhost:3333'
+// In dev, prefer relative path to use Vite proxy. Allow override via VITE_API_BASE_URL.
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? ''
 
 const buildUrl = (path: string) => {
   const normalizedBase = API_BASE_URL.replace(/\/$/, '')

--- a/apps/web/src/state/store.ts
+++ b/apps/web/src/state/store.ts
@@ -177,8 +177,10 @@ const contractToSnapshot = (result: ProcessMessageResponse, previous: DiagramSna
     }
   }
 
+  // Backend currently returns mermaid flowchart when not mindmap.
+  // Always align the visualizer to flowchart in that case to avoid blank sequence rendering.
   return {
-    type: previous.type === 'sequence' ? 'sequence' : 'flowchart',
+    type: 'flowchart',
     mermaid: typeof result.diagram.dsl === 'string' ? result.diagram.dsl : previous.mermaid,
     mindmapNodes: previous.mindmapNodes,
   }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,4 +4,14 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/v1': 'http://localhost:3333',
+    },
+  },
+  preview: {
+    proxy: {
+      '/v1': 'http://localhost:3333',
+    },
+  },
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fastify/websocket": "^8.3.1",
         "dagre": "^0.8.5",
+        "dotenv": "^17.2.3",
         "fastify": "^4.25.2",
         "nanoid": "^4.0.2"
       },
@@ -1353,6 +1354,18 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/esbuild": {

--- a/package.json
+++ b/package.json
@@ -12,12 +12,13 @@
   "dependencies": {
     "@fastify/websocket": "^8.3.1",
     "dagre": "^0.8.5",
+    "dotenv": "^17.2.3",
     "fastify": "^4.25.2",
     "nanoid": "^4.0.2"
   },
   "devDependencies": {
-    "@types/node": "^20.11.30",
     "@types/dagre": "^0.7.46",
+    "@types/node": "^20.11.30",
     "@vitest/coverage-v8": "^1.6.0",
     "tsx": "^4.7.1",
     "typescript": "^5.4.3",

--- a/services/api/src/pipeline/entityExtractor.ts
+++ b/services/api/src/pipeline/entityExtractor.ts
@@ -1,20 +1,22 @@
 import { maskPII } from '../guards.js';
 
-const ENTITY_REGEX = /(?:^|\b)([A-Z][a-zA-Z0-9]+(?:\s+[A-Z][a-zA-Z0-9]+)*)/g;
+// Support Latin capitalized terms and basic Japanese token boundaries（ひらがな・カタカナ・漢字のまとまり）
+const ENTITY_REGEX = /(?:^|\b)([A-Z][a-zA-Z0-9]+(?:\s+[A-Z][a-zA-Z0-9]+)*)|([\u3040-\u30ff\u4e00-\u9faf]{2,})/g;
 
 export function extractEntities(text: string): string[] {
   const sanitized = maskPII(text);
   const entities = new Set<string>();
   let match: RegExpExecArray | null;
   while ((match = ENTITY_REGEX.exec(sanitized)) !== null) {
-    const entity = match[1].trim();
+    const entity = (match[1] || match[2] || '').trim();
     if (entity.length > 1 && entity.length < 50) {
       entities.add(entity);
     }
   }
   if (entities.size === 0) {
+    // Accept arrow-separated flows and mixed language tokens
     const tokens = sanitized
-      .split(/[^a-zA-Z0-9]+/)
+      .split(/(?:->|→|⇒|➡︎|➡|→|\s|,|、|。|\.|;|:)+/)
       .filter((token) => token.length > 3)
       .slice(0, 5)
       .map((token) => token[0].toUpperCase() + token.slice(1));

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import Fastify from 'fastify';
 import { DiagramService } from './service.js';
 import { diagramRoutes } from './routes/diagram.js';


### PR DESCRIPTION
## Summary
- add API client helpers to create sessions and process chat messages via the LLM pipeline
- extend the Zustand store to manage backend sessions, convert diagram contracts, and append assistant responses
- update the chat panel UI to dispatch LLM updates automatically and reflect in-progress processing state

## Testing
- npm run build --prefix apps/web
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e28c46e1bc83218bce811eb57e9bee